### PR TITLE
Fix Catalyst support

### DIFF
--- a/Sources/Inspector/Extensions/UIView/UIView+ViewHierarchyElementRepresentable.swift
+++ b/Sources/Inspector/Extensions/UIView/UIView+ViewHierarchyElementRepresentable.swift
@@ -65,9 +65,11 @@ extension UIView: ViewHierarchyElementRepresentable {
         _isSystemContainer
     }
 
+    #if !targetEnvironment(macCatalyst)
     var className: String {
         _className
     }
+    #endif
 
     var classNameWithoutQualifiers: String {
         _classNameWithoutQualifiers


### PR DESCRIPTION
To support Catalyst targets, disable the `className` computed property inside the UIView extension

Ref: https://developer.apple.com/documentation/objectivec/nsobject/1411337-classname